### PR TITLE
Fix incorrect HTML font tag

### DIFF
--- a/Recorder_Tablature.qml
+++ b/Recorder_Tablature.qml
@@ -170,8 +170,8 @@ MuseScore {
                         var index = pitch - basePitch;
                         if(index >= 0 && index < fingerings.length){ 
                               var text = newElement(Element.STAFF_TEXT);
-                              text.text = "<font face=\"Recorder Font\"/>"+fingerings[index];
-                              text.text = "<font size=\""+size+"\"/>"+text.text;
+                              text.text = "<font face=\"Recorder Font\">"+fingerings[index];
+                              text.text = "<font size=\""+size+"\">"+text.text;
                               text.text = text.text + "</font></font>";
 console.log(text.text);
                               text.pos.y = 10;


### PR DESCRIPTION
- Font tag was closed with "/>" which causes error on "</font>" since
the tag was already closed.